### PR TITLE
Soft pwm

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2021"
 
 [dependencies]
 panic-halt = "0.2.0"
+deposit-iter = {git="https://github.com/simonsso/deposit_iter.git", branch="master"}
 [dependencies.avrd]
 git = "https://github.com/avr-rust/avrd.git"
 branch = "master"

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,64 +4,94 @@
 const INTERNAL_MAX: i32 = 0xFF00;
 extern crate panic_halt;
 
-use arduino_hal::simple_pwm::*;
 use core::ops;
 
 #[arduino_hal::entry]
 fn main() -> ! {
     let dp = arduino_hal::Peripherals::take().unwrap();
     let pins = arduino_hal::pins!(dp);
-    let timer1 = Timer1Pwm::new(dp.TC1, Prescaler::Direct);
-    let mut d4 = pins.d4.into_output().into_pwm(&timer1);
+    let mut d4 = pins.d4.into_output();
 
-    let timer0 = Timer0Pwm::new(dp.TC0, Prescaler::Direct);
+    // let timer0 = Timer0Pwm::new(dp.TC0, Prescaler::Direct);
 
-    let mut d0 = pins.d0.into_output().into_pwm(&timer0);
-    let mut d1 = pins.d1.into_output().into_pwm(&timer0);
+    let mut d0 = pins.d0.into_output();
+    let mut d1 = pins.d1.into_output();
 
-    d0.enable();
-    d1.enable();
-    d4.enable();
+    d0.set_low();
+    d1.set_low();
+    d4.set_low();
 
     let mut duty_0 = Duty::new();
     let mut duty_1 = Duty::new();
     let mut duty_4 = Duty::new();
     loop {
-        d0.set_duty(duty_0.get());
-        d1.set_duty(duty_1.get());
-        d4.set_duty(duty_4.get());
+        let mut d0_pwm_duty = Deposit::new(duty_0.get());
+        let mut d1_pwm_duty = Deposit::new(duty_1.get());
+        let mut d4_pwm_duty = Deposit::new(duty_4.get());
+        d0.set_high();
+        d1.set_high();
+        d4.set_high();
+        for _ in 0..256 {
+            if Some(true) == d0_pwm_duty.next() {
+                d0.set_low();
+            }
+            if Some(true) == d1_pwm_duty.next() {
+                d1.set_low();
+            }
+            if Some(true) == d4_pwm_duty.next() {
+                d4.set_low();
+            }
+            arduino_hal::delay_us(30);
+        }
+        arduino_hal::delay_ms(2);
+
+        // d1.toggle();
 
         duty_0 += 29;
         duty_1 += 13;
         duty_4 += 37;
-        arduino_hal::delay_ms(20);
+    }
+}
+#[derive(Default)]
+struct Deposit {
+    times: Option<u8>,
+}
+
+impl Deposit {
+    fn new(t: u8) -> Self {
+        Deposit { times: Some(t) }
+    }
+}
+impl Iterator for Deposit {
+    type Item = bool;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if let Some(times) = self.times {
+            if times == 0 {
+                self.times = None;
+                Some(true)
+            } else {
+                self.times = Some(times.saturating_sub(1));
+                Some(false)
+            }
+        } else {
+            None
+        }
     }
 }
 
-/// Modified Sine table with longer time at 0
-const SINE: [u8; 256] = [
-    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 2, 2, 3, 4, 5, 5, 6, 7, 9, 10, 11, 12,
-    14, 15, 17, 18, 20, 21, 23, 25, 27, 29, 31, 33, 35, 37, 40, 42, 44, 47, 49, 52, 54, 57, 59, 62,
-    65, 67, 70, 73, 76, 79, 82, 85, 88, 90, 93, 97, 100, 103, 106, 109, 112, 115, 118, 121, 124,
-    128, 131, 134, 137, 140, 143, 146, 149, 152, 155, 158, 162, 165, 167, 170, 173, 176, 179, 182,
-    185, 188, 190, 193, 196, 198, 201, 203, 206, 208, 211, 213, 215, 218, 220, 222, 224, 226, 228,
-    230, 232, 234, 235, 237, 238, 240, 241, 243, 244, 245, 246, 248, 249, 250, 250, 251, 252, 253,
-    253, 254, 254, 254, 253, 253, 252, 251, 250, 250, 249, 248, 246, 245, 244, 243, 241, 240, 238,
-    237, 235, 234, 232, 230, 228, 226, 224, 222, 220, 218, 215, 213, 211, 208, 206, 203, 201, 198,
-    196, 193, 190, 188, 185, 182, 179, 176, 173, 170, 167, 165, 162, 158, 155, 152, 149, 146, 143,
-    140, 137, 134, 131, 128, 124, 121, 118, 115, 112, 109, 106, 103, 100, 97, 93, 90, 88, 85, 82,
-    79, 76, 73, 70, 67, 65, 62, 59, 57, 54, 52, 49, 47, 44, 42, 40, 37, 35, 33, 31, 29, 27, 25, 23,
-    21, 20, 18, 17, 15, 14, 12, 11, 10, 9, 7, 6, 5, 5, 4, 3, 2, 2, 1, 1, 1, 0,
-];
 struct Duty {
     internal: i32,
 }
 impl Duty {
     fn new() -> Self {
-        Duty { internal: 0 }
+        Duty {
+            internal: -INTERNAL_MAX,
+        }
     }
     fn get(&self) -> u8 {
-        SINE[(self.internal.abs() as u32).to_le_bytes()[1] as usize]
+        // SINE[(self.internal.abs() as u32).to_le_bytes()[1] as usize]
+        (self.internal.abs() as u32).to_le_bytes()[1] / 2
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,6 +6,8 @@ extern crate panic_halt;
 
 use core::ops;
 
+use deposit_iter::Deposit;
+
 #[arduino_hal::entry]
 fn main() -> ! {
     let dp = arduino_hal::Peripherals::take().unwrap();
@@ -25,9 +27,9 @@ fn main() -> ! {
     let mut duty_1 = Duty::new();
     let mut duty_4 = Duty::new();
     loop {
-        let mut d0_pwm_duty = Deposit::new(duty_0.get());
-        let mut d1_pwm_duty = Deposit::new(duty_1.get());
-        let mut d4_pwm_duty = Deposit::new(duty_4.get());
+        let mut d0_pwm_duty = Deposit::new(duty_0.get().into());
+        let mut d1_pwm_duty = Deposit::new(duty_1.get().into());
+        let mut d4_pwm_duty = Deposit::new(duty_4.get().into());
         d0.set_high();
         d1.set_high();
         d4.set_high();
@@ -53,32 +55,6 @@ fn main() -> ! {
     }
 }
 #[derive(Default)]
-struct Deposit {
-    times: Option<u8>,
-}
-
-impl Deposit {
-    fn new(t: u8) -> Self {
-        Deposit { times: Some(t) }
-    }
-}
-impl Iterator for Deposit {
-    type Item = bool;
-
-    fn next(&mut self) -> Option<Self::Item> {
-        if let Some(times) = self.times {
-            if times == 0 {
-                self.times = None;
-                Some(true)
-            } else {
-                self.times = Some(times.saturating_sub(1));
-                Some(false)
-            }
-        } else {
-            None
-        }
-    }
-}
 
 struct Duty {
     internal: i32,
@@ -94,7 +70,6 @@ impl Duty {
         (self.internal.abs() as u32).to_le_bytes()[1] / 2
     }
 }
-
 impl ops::AddAssign<i32> for Duty {
     fn add_assign(&mut self, incr: i32) {
         if self.internal + incr > INTERNAL_MAX {

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,26 +12,35 @@ use deposit_iter::Deposit;
 fn main() -> ! {
     let dp = arduino_hal::Peripherals::take().unwrap();
     let pins = arduino_hal::pins!(dp);
-    let mut d4 = pins.d4.into_output();
-
-    // let timer0 = Timer0Pwm::new(dp.TC0, Prescaler::Direct);
 
     let mut d0 = pins.d0.into_output();
     let mut d1 = pins.d1.into_output();
+    let mut d2 = pins.d2.into_output();
+    let mut d3 = pins.d3.into_output();
+    let mut d4 = pins.d4.into_output();
 
     d0.set_low();
     d1.set_low();
+    d2.set_low();
+    d3.set_low();
     d4.set_low();
 
     let mut duty_0 = Duty::new();
     let mut duty_1 = Duty::new();
+    let mut duty_2 = Duty::new();
+    let mut duty_3 = Duty::new();
     let mut duty_4 = Duty::new();
+
     loop {
         let mut d0_pwm_duty = Deposit::new(duty_0.get().into());
         let mut d1_pwm_duty = Deposit::new(duty_1.get().into());
+        let mut d2_pwm_duty = Deposit::new(duty_2.get().into());
+        let mut d3_pwm_duty = Deposit::new(duty_3.get().into());
         let mut d4_pwm_duty = Deposit::new(duty_4.get().into());
         d0.set_high();
         d1.set_high();
+        d2.set_high();
+        d3.set_high();
         d4.set_high();
         for _ in 0..256 {
             if Some(true) == d0_pwm_duty.next() {
@@ -40,6 +49,12 @@ fn main() -> ! {
             if Some(true) == d1_pwm_duty.next() {
                 d1.set_low();
             }
+            if Some(true) == d2_pwm_duty.next() {
+                d2.set_low();
+            }
+            if Some(true) == d3_pwm_duty.next() {
+                d3.set_low();
+            }
             if Some(true) == d4_pwm_duty.next() {
                 d4.set_low();
             }
@@ -47,10 +62,10 @@ fn main() -> ! {
         }
         arduino_hal::delay_ms(2);
 
-        // d1.toggle();
-
         duty_0 += 29;
         duty_1 += 13;
+        duty_2 += 17;
+        duty_3 += 23;
         duty_4 += 37;
     }
 }


### PR DESCRIPTION
Replace hardware PWM with soft PWM.

The speed of pulse width modulation only needs to fool a human eye. This can be achieved with bit banging on all digital ports, hence enable 5 outputs on an AT85.